### PR TITLE
:sparkles: Add proxy & format none support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ Options:
   --to                End date (YYYY-MM-DD or 'now') [default: now]
   -t, --timeframe     Timeframe: tick, m1, m5, m15, m30, h1, h4, D, W, M [default: D]
   -p, --price-type    Price type: bid, ask, mid [default: bid]
-  -f, --format        Output format: csv, json, ndjson [default: csv]
+  -f, --format        Output format: csv, json, ndjson, none [default: csv]
   -o, --output        Output directory [default: ./download]
+  --cache             Enable file caching [default: false]
+  --proxy             Proxy URL (http://[user:pass@]host:port or socks5://host:port)
+  --continue-on-error Continue on fetch errors (WARNING: may cause data gaps)
   -h, --help          Show help message
 ```
 

--- a/lib/dukascopy/cli.ex
+++ b/lib/dukascopy/cli.ex
@@ -109,10 +109,14 @@ defmodule Dukascopy.CLI do
     end_time = System.monotonic_time(:millisecond)
     duration = end_time - start_time
 
-    file_path
-    |> File.stat!()
-    |> Map.get(:size)
-    |> then(&Printer.print_success(file_path, &1, duration))
+    if opts.format != :none do
+      file_path
+      |> File.stat!()
+      |> Map.get(:size)
+      |> then(&Printer.print_success(file_path, &1, duration))
+    else
+      Printer.print_none_success(duration)
+    end
 
     :ok
   end
@@ -134,6 +138,8 @@ defmodule Dukascopy.CLI do
       retry_delay: opts.retry_delay,
       retry_on_empty: opts.retry_on_empty,
       fail_after_retry_count: opts.fail_after_retry_count,
+      halt_on_error: opts.halt_on_error,
+      proxy: opts.proxy,
       market_open: opts.market_open,
       weekly_open: opts.weekly_open
     ]
@@ -142,19 +148,20 @@ defmodule Dukascopy.CLI do
   end
 
   defp write_with_progress(stream, file_path, opts, has_progress) do
-    file_path
-    |> Path.dirname()
-    |> File.mkdir_p!()
+    if opts.format != :none do
+      file_path |> Path.dirname() |> File.mkdir_p!()
+    end
 
-    file = File.open!(file_path, [:write, :utf8])
+    file = if opts.format != :none, do: File.open!(file_path, [:write, :utf8])
 
     case opts.format do
       :csv -> write_csv_with_progress(file, stream, opts, has_progress)
       :json -> write_json_with_progress(file, stream, opts, has_progress)
       :ndjson -> write_ndjson_with_progress(file, stream, opts, has_progress)
+      :none -> write_none_with_progress(stream, opts, has_progress)
     end
 
-    File.close(file)
+    if file, do: File.close(file)
   end
 
   defp write_csv_with_progress(file, stream, opts, has_progress) do
@@ -183,6 +190,12 @@ defmodule Dukascopy.CLI do
     stream
     |> maybe_with_progress(opts, has_progress)
     |> Enum.each(&IO.puts(file, Formatter.to_json(&1)))
+  end
+
+  defp write_none_with_progress(stream, opts, has_progress) do
+    stream
+    |> maybe_with_progress(opts, has_progress)
+    |> Stream.run()
   end
 
   defp maybe_with_progress(stream, opts, true) do

--- a/lib/dukascopy/cli/options.ex
+++ b/lib/dukascopy/cli/options.ex
@@ -48,9 +48,9 @@ defmodule Dukascopy.CLI.Options do
       doc: "Include flat (zero-volume) bars"
     ],
     format: [
-      type: {:in, ["csv", "json", "ndjson"]},
+      type: {:in, ["csv", "json", "ndjson", "none"]},
       default: "csv",
-      doc: "Output format"
+      doc: "Output format (none = no file output, useful with --cache)"
     ],
     output: [
       type: :string,
@@ -97,6 +97,15 @@ defmodule Dukascopy.CLI.Options do
       default: true,
       doc: "Fail after all retries exhausted"
     ],
+    continue_on_error: [
+      type: :boolean,
+      default: false,
+      doc: "Continue on fetch errors (WARNING: may cause data gaps)"
+    ],
+    proxy: [
+      type: :string,
+      doc: "Proxy URL (http://[user:pass@]host:port or socks5://host:port)"
+    ],
     market_open: [
       type: :string,
       default: "00:00:00",
@@ -139,6 +148,8 @@ defmodule Dukascopy.CLI.Options do
       retry_pause: :integer,
       retry_on_empty: :boolean,
       fail_after_retries: :boolean,
+      continue_on_error: :boolean,
+      proxy: :string,
       market_open: :string,
       weekly_open: :string,
       silent: :boolean,
@@ -209,7 +220,7 @@ defmodule Dukascopy.CLI.Options do
       --flats             Include flat (zero-volume) bars [default: false]
 
     Output options:
-      -f, --format        Output format: csv, json, ndjson [default: csv]
+      -f, --format        Output format: csv, json, ndjson, none [default: csv]
       -o, --output        Output directory [default: ./download]
       --filename          Custom filename (without extension)
 
@@ -222,6 +233,8 @@ defmodule Dukascopy.CLI.Options do
       --retry-pause       Pause between retries in ms [default: 500]
       --retry-on-empty    Retry on empty response [default: false]
       --no-fail-after-retries  Don't fail after all retries
+      --continue-on-error Continue on fetch errors (WARNING: may cause data gaps)
+      --proxy             Proxy URL (http://[user:pass@]host:port or socks5://host:port)
 
     Aggregation options:
       --market-open       Market open time (HH:MM:SS) [default: 00:00:00]
@@ -261,6 +274,8 @@ defmodule Dukascopy.CLI.Options do
       retry_delay: opts[:retry_pause],
       retry_on_empty: opts[:retry_on_empty],
       fail_after_retry_count: opts[:fail_after_retries],
+      halt_on_error: not opts[:continue_on_error],
+      proxy: opts[:proxy],
       market_open: parse_time(opts[:market_open]),
       weekly_open: String.to_atom(opts[:weekly_open]),
       silent: opts[:silent],

--- a/lib/dukascopy/cli/printer.ex
+++ b/lib/dukascopy/cli/printer.ex
@@ -39,6 +39,21 @@ defmodule Dukascopy.CLI.Printer do
     IO.puts("")
   end
 
+  def print_none_success(duration_ms) do
+    print_divider()
+
+    message =
+      IO.ANSI.green() <>
+        IO.ANSI.bright() <>
+        "Stream completed" <>
+        IO.ANSI.reset()
+
+    IO.puts(message)
+    IO.puts("Duration: #{format_duration(duration_ms)}")
+    IO.puts("(No output file - format: none)")
+    IO.puts("")
+  end
+
   def print_error(message) do
     IO.puts(:stderr, IO.ANSI.red() <> IO.ANSI.bright() <> "Error: #{message}" <> IO.ANSI.reset())
   end

--- a/lib/dukascopy/client.ex
+++ b/lib/dukascopy/client.ex
@@ -15,7 +15,8 @@ defmodule Dukascopy.Client do
     :retry_log_level,
     :use_cache,
     :cache_folder_path,
-    :fail_after_retry_count
+    :fail_after_retry_count,
+    :proxy
   ]
 
   ## Public API
@@ -46,6 +47,7 @@ defmodule Dukascopy.Client do
     )
     |> Req.Request.register_options(@client_options)
     |> Req.Request.merge_options(client_opts)
+    |> maybe_add_proxy(client_opts)
     |> maybe_add_cache_steps(client_opts)
     |> Req.Request.append_response_steps(decompress_lzma: &decompress_lzma/1)
   end
@@ -60,6 +62,40 @@ defmodule Dukascopy.Client do
       %Req.Response{} -> true
       %{__exception__: true} -> true
       _ -> false
+    end
+  end
+
+  defp maybe_add_proxy(req, opts) do
+    case Keyword.get(opts, :proxy) do
+      nil ->
+        req
+
+      proxy_url ->
+        Req.Request.merge_options(req, connect_options: [proxy: parse_proxy(proxy_url)])
+    end
+  end
+
+  defp parse_proxy(proxy_url) when is_binary(proxy_url) do
+    uri = URI.parse(proxy_url)
+
+    case uri.scheme do
+      "socks5" ->
+        {:socks5, uri.host, uri.port || 1080}
+
+      scheme when scheme in ["http", "https"] ->
+        auth_opts =
+          if uri.userinfo do
+            [user, pass] = String.split(uri.userinfo, ":", parts: 2)
+            [proxy_auth: {:basic, user, pass}]
+          else
+            []
+          end
+
+        {String.to_atom(scheme), uri.host, uri.port || 8080, auth_opts}
+
+      other ->
+        raise ArgumentError,
+              "Unsupported proxy scheme: #{other}. Use http://, https://, or socks5://"
     end
   end
 
@@ -91,20 +127,28 @@ defmodule Dukascopy.Client do
     cache_file = cache_file_path(request.url, cache_path)
 
     case File.read(cache_file) do
-      {:ok, data} -> {request, Req.Response.new(status: 200, body: data)}
-      {:error, :enoent} -> request
+      {:ok, data} ->
+        enhanced_request = Req.Request.put_private(request, :cache_hit, true)
+        {enhanced_request, Req.Response.new(status: 200, body: data)}
+
+      {:error, :enoent} ->
+        request
     end
   end
 
   defp cache_write({request, %Req.Response{status: 200, body: body} = response})
        when byte_size(body) > 0 do
-    cache_path = request.options[:cache_folder_path] || @default_cache_folder_path
-    cache_file = cache_file_path(request.url, cache_path)
+    if request.private[:cache_hit] do
+      {request, response}
+    else
+      cache_path = request.options[:cache_folder_path] || @default_cache_folder_path
+      cache_file = cache_file_path(request.url, cache_path)
 
-    :ok = File.mkdir_p!(cache_path)
-    :ok = File.write!(cache_file, body)
+      :ok = File.mkdir_p!(cache_path)
+      :ok = File.write!(cache_file, body)
 
-    {request, response}
+      {request, response}
+    end
   end
 
   defp cache_write({request, response}), do: {request, response}

--- a/lib/dukascopy/options.ex
+++ b/lib/dukascopy/options.ex
@@ -84,7 +84,8 @@ defmodule Dukascopy.Options do
       # Default exponential backoff: 200ms, 400ms, 800ms, 1600ms...
       retry_delay: &trunc(200 * :math.pow(2, &1)),
       market_open: ~T[00:00:00],
-      weekly_open: :monday
+      weekly_open: :monday,
+      proxy: nil
     ]
   end
 

--- a/test/dukascopy/client_cache_test.exs
+++ b/test/dukascopy/client_cache_test.exs
@@ -133,4 +133,32 @@ defmodule Dukascopy.ClientCacheTest do
       refute File.exists?(cache_path)
     end
   end
+
+  describe "cache optimization" do
+    test "does not rewrite cache file when reading from cache", %{cache_path: cache_path} do
+      # Pre-populate cache with a file (LZMA compressed)
+      File.mkdir_p!(cache_path)
+      cache_file = Path.join(cache_path, "preexisting.bi5")
+      File.write!(cache_file, @valid_fixture)
+
+      # Get the original modification time
+      {:ok, %{mtime: original_mtime}} = File.stat(cache_file)
+
+      # Small delay to ensure mtime would change if file is rewritten
+      Process.sleep(10)
+
+      {opts, counter} = TestStubs.counting_fixed_stub(:cache_no_rewrite, 200, "new content")
+      opts = Keyword.merge(opts, use_cache: true, cache_folder_path: cache_path)
+
+      # Fetch - should read from cache (returns decompressed data)
+      assert {:ok, _decompressed_data} = Client.fetch("preexisting.bi5", opts)
+
+      # Network should not have been called
+      assert TestStubs.get_count(counter) == 0
+
+      # File should not have been rewritten (mtime unchanged)
+      {:ok, %{mtime: new_mtime}} = File.stat(cache_file)
+      assert original_mtime == new_mtime
+    end
+  end
 end

--- a/test/dukascopy/client_proxy_test.exs
+++ b/test/dukascopy/client_proxy_test.exs
@@ -1,0 +1,85 @@
+defmodule Dukascopy.ClientProxyTest do
+  use ExUnit.Case, async: true
+
+  alias Dukascopy.Client
+
+  ## Tests
+
+  describe "proxy URL parsing" do
+    test "parses HTTP proxy URL without auth" do
+      # We can't easily test the actual proxy connection without a proxy server,
+      # but we can verify the option is accepted and doesn't raise
+      opts = [plug: {Req.Test, :proxy_http}, max_retries: 0]
+
+      Req.Test.stub(:proxy_http, fn conn ->
+        Req.Test.json(conn, %{})
+      end)
+
+      # Should not raise when proxy option is provided
+      assert {:error, _} =
+               Client.fetch("test.bi5", Keyword.put(opts, :proxy, "http://localhost:8080"))
+    end
+
+    test "parses HTTPS proxy URL without auth" do
+      opts = [plug: {Req.Test, :proxy_https}, max_retries: 0]
+
+      Req.Test.stub(:proxy_https, fn conn ->
+        Req.Test.json(conn, %{})
+      end)
+
+      # Should not raise when proxy option is provided
+      assert {:error, _} =
+               Client.fetch("test.bi5", Keyword.put(opts, :proxy, "https://localhost:8080"))
+    end
+
+    test "parses SOCKS5 proxy URL" do
+      opts = [plug: {Req.Test, :proxy_socks5}, max_retries: 0]
+
+      Req.Test.stub(:proxy_socks5, fn conn ->
+        Req.Test.json(conn, %{})
+      end)
+
+      # Should not raise when proxy option is provided
+      assert {:error, _} =
+               Client.fetch("test.bi5", Keyword.put(opts, :proxy, "socks5://localhost:1080"))
+    end
+
+    test "parses HTTP proxy URL with authentication" do
+      opts = [plug: {Req.Test, :proxy_auth}, max_retries: 0]
+
+      Req.Test.stub(:proxy_auth, fn conn ->
+        Req.Test.json(conn, %{})
+      end)
+
+      # Should not raise when proxy with auth is provided
+      assert {:error, _} =
+               Client.fetch(
+                 "test.bi5",
+                 Keyword.put(opts, :proxy, "http://user:pass@localhost:8080")
+               )
+    end
+
+    test "raises on unsupported proxy scheme" do
+      opts = [plug: {Req.Test, :proxy_invalid}, max_retries: 0]
+
+      Req.Test.stub(:proxy_invalid, fn conn ->
+        Req.Test.json(conn, %{})
+      end)
+
+      assert_raise ArgumentError, ~r/Unsupported proxy scheme/, fn ->
+        Client.fetch("test.bi5", Keyword.put(opts, :proxy, "ftp://localhost:21"))
+      end
+    end
+
+    test "works without proxy (nil)" do
+      opts = [plug: {Req.Test, :no_proxy}, max_retries: 0]
+
+      Req.Test.stub(:no_proxy, fn conn ->
+        Req.Test.json(conn, %{})
+      end)
+
+      # Should not raise when no proxy
+      assert {:error, _} = Client.fetch("test.bi5", Keyword.put(opts, :proxy, nil))
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1

## Summary

- Add cache optimization to skip redundant disk writes when file already exists in cache
- Add `none` format option to stream data without creating output file (useful with `--cache` to pre-populate cache)
- Add proxy support with HTTP, HTTPS, and SOCKS5 (`--proxy` option)
- Add `--continue-on-error` option to continue downloading even when individual fetches fail

## Changes

### Cache optimization
Use `Req.Request.put_private` to pass a `:cache_hit` flag between cache steps, avoiding unnecessary file rewrites when data is already cached.

### Format `none`
New format that iterates the stream without writing to disk. Example:
```bash
dukascopy download -i EUR/USD --from 2024-01-01 --to 2024-01-31 --cache -f none
